### PR TITLE
Add FastAPI sharing starter with QR splash page

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,6 @@
+:8443 {
+    encode gzip zstd
+    reverse_proxy 127.0.0.1:8000
+    tls internal
+    header Strict-Transport-Security "max-age=31536000; includeSubDomains"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
-# OrderedDiscipline
+# OrderedDiscipline – laptop ➜ phone sharing kit
+
+This starter project bundles a FastAPI application, a QR code splash page, and optional reverse proxy / tunnelling helpers so you can share anything running on your laptop with your phone in seconds.
+
+## Features
+
+- 📱 **QR splash page** – just scan from your phone to open the link.
+- ⚡️ **FastAPI + Uvicorn** – lightweight web server for APIs or static hosting.
+- 🔐 **Caddy reverse proxy** – serve HTTPS on your LAN with an automatically trusted certificate.
+- ☁️ **Cloudflared tunnel** – expose the service to the internet securely without router changes.
+
+## Quick start
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+./scripts/run_local.sh
+```
+
+By default the app binds to `0.0.0.0:8000` and attempts to detect your LAN IP. Point your phone browser to the printed URL or just scan the QR code at `http://<laptop-ip>:8000`.
+
+> **Tip** – override the link encoded in the QR by exporting `SHARE_URL="https://your-public-url"` before launching the server.
+
+## Project layout
+
+```
+app/
+  main.py          # FastAPI app with QR landing page
+Caddyfile          # HTTPS reverse proxy (optional)
+cloudflared.yml    # Sample config for a named Cloudflare Tunnel
+requirements.txt   # Python dependencies
+scripts/run_local.sh
+templates/landing.html
+```
+
+## Running behind Caddy (HTTPS on LAN)
+
+1. Install Caddy (`brew install caddy` on macOS).
+2. Start the FastAPI server: `./scripts/run_local.sh`.
+3. In a new terminal run `caddy run --config Caddyfile`.
+4. On your phone visit `https://<laptop-ip>:8443` and accept the certificate once.
+
+The bundled `Caddyfile` enables gzip/zstd compression and enforces HSTS for good defaults.
+
+## Cloudflare Tunnel (public URL without port-forwarding)
+
+1. Install cloudflared (`brew install cloudflared`).
+2. With the FastAPI server running, launch an ad-hoc tunnel:
+   ```bash
+   cloudflared tunnel --url http://localhost:8000
+   ```
+   The CLI prints a `https://trycloudflare.com` URL. Export this as `SHARE_URL` so the QR code directs phones to the public address:
+   ```bash
+   SHARE_URL="https://<random>.trycloudflare.com" ./scripts/run_local.sh
+   ```
+3. For repeatable tunnels using your own hostname, log into Cloudflare, create a named tunnel, and adapt the sample `cloudflared.yml`.
+
+## ngrok alternative
+
+```bash
+brew install ngrok
+ngrok config add-authtoken <YOUR_TOKEN>
+ngrok http 8000
+```
+
+Use `SHARE_URL=$(ngrok url https) ./scripts/run_local.sh` if you want the QR page to point at the ngrok domain automatically.
+
+## Health check & API
+
+- `GET /` – HTML landing page with QR code
+- `GET /api/info` – returns `{ "share_url": "..." }`
+- `GET /health` – simple JSON health indicator for monitoring
+
+## Security checklist
+
+- Only bind to `0.0.0.0` on trusted networks.
+- Prefer Cloudflare Tunnel or ngrok over router port-forwarding.
+- Protect any sensitive routes with auth (Basic, OAuth, JWT, etc.).
+- Keep dependencies patched (`pip install --upgrade -r requirements.txt`).
+
+## License
+
+[CC0 1.0](LICENSE)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application package for OrderedDiscipline."""

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,83 @@
+"""FastAPI application exposing a QR-code splash page for easy device pairing."""
+
+from __future__ import annotations
+
+import base64
+import os
+import socket
+from functools import lru_cache
+from io import BytesIO
+
+import qrcode
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
+
+TEMPLATES = Jinja2Templates(directory="templates")
+
+app = FastAPI(title="OrderedDiscipline Share Server", version="0.1.0")
+
+
+@lru_cache(maxsize=1)
+def _local_ip() -> str:
+    """Return the LAN IP address that other devices can reach."""
+
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("1.1.1.1", 80))
+            return sock.getsockname()[0]
+    except OSError:
+        return "127.0.0.1"
+
+
+def get_share_url() -> str:
+    """Resolve the URL that should appear on the splash page."""
+
+    return os.environ.get("SHARE_URL", f"http://{_local_ip()}:8000")
+
+
+@lru_cache(maxsize=32)
+def qr_for_url(url: str) -> str:
+    """Return a base64-encoded PNG QR code for ``url``."""
+
+    image = qrcode.make(url)
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    encoded = base64.b64encode(buffer.getvalue()).decode()
+    return f"data:image/png;base64,{encoded}"
+
+
+def share_url_dependency() -> str:
+    return get_share_url()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def landing_page(request: Request, share_url: str = Depends(share_url_dependency)) -> HTMLResponse:
+    """Render the splash page with a QR code that targets the share URL."""
+
+    qr_image = qr_for_url(share_url)
+    return TEMPLATES.TemplateResponse(
+        "landing.html",
+        {
+            "request": request,
+            "share_url": share_url,
+            "qr_image": qr_image,
+        },
+    )
+
+
+@app.get("/api/info")
+async def info(share_url: str = Depends(share_url_dependency)) -> JSONResponse:
+    """Provide metadata that clients can query programmatically."""
+
+    return JSONResponse({"share_url": share_url})
+
+
+@app.get("/health")
+async def healthcheck() -> JSONResponse:
+    """Simple health-check endpoint for reverse-proxy monitoring."""
+
+    return JSONResponse({"status": "ok"})
+
+
+__all__ = ["app"]

--- a/cloudflared.yml
+++ b/cloudflared.yml
@@ -1,0 +1,8 @@
+# Example configuration for a named Cloudflare Tunnel.
+ingress:
+  - hostname: share.example.com
+    service: http://localhost:8000
+  - service: http_status:404
+
+warp-routing:
+  enabled: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.109,<1.0
+uvicorn[standard]>=0.27,<0.30
+qrcode[pil]>=7.4,<8.0
+jinja2>=3.1,<4.0

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_URL=$(python - <<'PY'
+import socket
+try:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.connect(("1.1.1.1", 80))
+        print(f"http://{sock.getsockname()[0]}:8000")
+except OSError:
+    print("http://127.0.0.1:8000")
+PY
+)
+
+export UVICORN_WORKERS="${UVICORN_WORKERS:-1}"
+export SHARE_URL="${SHARE_URL:-$DEFAULT_URL}"
+
+exec uvicorn app.main:app --host 0.0.0.0 --port "${PORT:-8000}" --workers "$UVICORN_WORKERS"

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Share from your laptop</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color-scheme: light dark;
+        background-color: #0f172a;
+        color: #e2e8f0;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+      }
+
+      .card {
+        background: rgba(15, 23, 42, 0.9);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 24px;
+        padding: 2.5rem;
+        max-width: 480px;
+        text-align: center;
+        box-shadow: 0 30px 40px rgba(15, 23, 42, 0.45);
+      }
+
+      h1 {
+        font-size: clamp(1.6rem, 2.4vw, 2.2rem);
+        margin-bottom: 1rem;
+      }
+
+      p {
+        color: #cbd5f5;
+        margin-bottom: 1.5rem;
+        line-height: 1.6;
+      }
+
+      .qr-wrapper {
+        display: inline-flex;
+        padding: 1rem;
+        background: rgba(226, 232, 240, 0.1);
+        border-radius: 20px;
+      }
+
+      img.qr {
+        display: block;
+        width: 240px;
+        height: 240px;
+      }
+
+      .url {
+        margin-top: 1.5rem;
+        font-size: 0.95rem;
+        font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, monospace;
+        word-break: break-all;
+        color: #94a3b8;
+      }
+
+      footer {
+        margin-top: 2rem;
+        font-size: 0.75rem;
+        color: rgba(148, 163, 184, 0.75);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>Scan to open your laptop</h1>
+      <p>Point your phone camera at the QR code or type the URL below to connect instantly.</p>
+      <div class="qr-wrapper">
+        <img class="qr" src="{{ qr_image }}" alt="QR code for {{ share_url }}" />
+      </div>
+      <div class="url">{{ share_url }}</div>
+      <footer>Update the <code>SHARE_URL</code> env var to override this link.</footer>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a FastAPI application with a QR-code landing page for quick phone pairing
- include helper tooling for HTTPS on LAN via Caddy and secure public tunnelling via cloudflared
- document quick-start workflow, optional ngrok usage, and security considerations

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cf41b6258c8330b3ecb4cc6f90c5f2